### PR TITLE
F-Droid: Metadaten-Drift-Check und robuste Workflow-Guards

### DIFF
--- a/.github/scripts/bump-version.cjs
+++ b/.github/scripts/bump-version.cjs
@@ -112,21 +112,16 @@ writeFile(gradlePath, gradle);
 const fdroidPath = 'fdroid/metadata/io.github.gametrojaner.geburtstage.yml';
 let fdroid = readFile(fdroidPath);
 
-// Freeze the current HEAD entry with the old version's release tag
+// Backward compatibility: convert any legacy HEAD pin to the previous release tag.
 const oldTagRef = `v${oldVersion}`;
-const lastHeadIdx = fdroid.lastIndexOf('\n    commit: HEAD');
-if (lastHeadIdx !== -1) {
-  fdroid = fdroid.slice(0, lastHeadIdx)
-    + `\n    commit: ${oldTagRef}`
-    + fdroid.slice(lastHeadIdx + '\n    commit: HEAD'.length);
-}
+fdroid = fdroid.replace(/\n\s+commit:\s+HEAD\b/g, `\n    commit: ${oldTagRef}`);
 
 // Append new entry
 const newEntry = [
   '',
   `  - versionName: ${newVersion}`,
   `    versionCode: ${newVersionCode}`,
-  `    commit: HEAD`,
+  `    commit: v${newVersion}`,
   `    subdir: .`,
   `    sudo:`,
   `      - apt-get update`,
@@ -135,7 +130,7 @@ const newEntry = [
   `      - npm ci --legacy-peer-deps`,
   `    build:`,
   `      - npm run fdroid:check`,
-  `      - cd android && ./gradlew assembleRelease`,
+  `      - cd android && ./gradlew assembleRelease -Pfdroid.build=true`,
   '',
 ].join('\n');
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -178,6 +178,7 @@ Reagiert auf: WIDGET_ADDED, WIDGET_UPDATE, WIDGET_RESIZED.
 - **Patentpolitik**: Contributor Non-Assertion via `PATENTS.md`; Beitragspfad in `CONTRIBUTING.md`
 - **Third-Party-Lizenzen**: `THIRD_PARTY_LICENSES.md` wird per `npm run licenses:generate` aus installierten Paketen erzeugt und via `npm run licenses:check` validiert
 - **F-Droid Metadaten**: Entwurf liegt unter `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` (Quelle fuer spaetere fdroiddata-Submission)
+- **F-Droid Metadaten Drift-Check**: `npm run fdroid:metadata:drift` prueft Invarianten lokal und kann optional gegen fdroiddata vergleichen (`FDROID_METADATA_REF=<path|url>`)
 - **CI**: `.github/workflows/ci.yml` – Typecheck + Tests + Debug-APK bei PRs (mit `concurrency`, alte Runs werden abgebrochen); `.github/workflows/auto-version.yml` – automatische Versionserhöhung bei Merge (fix oder `[minor]`); `.github/workflows/release.yml` – manueller Release mit signiertem APK; `.github/workflows/fdroid-readiness.yml` prueft F-Droid-Checks und Lizenzdoku auf PRs nur bei F-Droid-relevanten Dateiaenderungen, fuehrt Typecheck/Unit-Tests auf PRs nur dann aus, wenn `ci.yml` diese nicht abdeckt (z.B. `fdroid/**`-only PRs), und laesst Heavy-Android-Schritte nur bei relevanten Aenderungen laufen; `.github/workflows/tests.yml` ist fuer manuelle Ad-hoc-Testlaeufe vorgesehen
 
 ## Befehle
@@ -193,6 +194,7 @@ npm run test:all:ci               # Typecheck + CI-Tests (mit Coverage)
 npm run test:coverage             # Tests mit Coverage
 npx tsc --noEmit                  # TypeScript Check
 npm run fdroid:check              # F-Droid Profil-Checks
+npm run fdroid:metadata:drift     # F-Droid Metadaten-Invarianten + optionaler Driftvergleich
 npm run fdroid:android            # Android Build mit F-Droid Profil
 npm run licenses:generate         # Third-Party-Lizenzdoku generieren
 npm run licenses:check            # Third-Party-Lizenzdoku pruefen

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -204,7 +204,7 @@ npm run licenses:check            # Third-Party-Lizenzdoku pruefen
 
 - **Notification-Offset-Kodierung**: Positive Werte = exakte Tage; negative Werte = Kalendermonate (z.B. `-1` = 1 Monat, `-2` = 2 Monate). Kodierung: `OffsetPickerDialog.tsx → toOffset()`; Darstellung: `getOffsetLabel()` in `birthday.ts`; Berechnung: `calculateNotificationDate()` in `birthday.ts` (Schaltjahr-sicher via Tages-Klammern).
 - **Benachrichtigungs-Bug (behoben)**: 1 Monat vor Geburtstag wurde als exakt 30 Tage berechnet, was zu falschen Benachrichtigungs-Zeitpunkten führte. Behoben durch `setMonth()` mit Schaltjahr-Klammerung.
-- **CI/CD**: 3 GitHub-Actions-Workflows: `ci.yml` (Typecheck + Tests + Debug-APK), `auto-version.yml` (Versionserhöhung bei Merge), `release.yml` (manueller Release mit signiertem APK). Shared Script: `.github/scripts/bump-version.cjs`.
+- **CI/CD**: 3 GitHub-Actions-Workflows: `ci.yml` (Typecheck + Tests + Debug-APK), `auto-version.yml` (Versionserhöhung bei Merge), `release.yml` (manueller Release mit signiertem APK). Shared Script: `.github/scripts/bump-version.cjs` (erzeugt in F-Droid-Metadaten getaggte `commit: v<version>`-Eintraege und setzt `assembleRelease -Pfdroid.build=true`).
 
 - TypeScript: 0 Fehler
 - **Tests**: 150/150 bestanden (18 Suites)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Beide Scripts installieren Node.js, Git, optional Android Studio, setzen Umgebun
 | `npm run test:watch` | Tests im Watch-Modus |
 | `npm run test:coverage` | Tests mit Coverage-Report |
 | `npm run fdroid:check` | Prueft F-Droid Build-Constraints (`FDROID_BUILD=1`) |
+| `npm run fdroid:metadata:drift` | Prueft F-Droid Metadaten-Invarianten; optional mit Referenzvergleich via `FDROID_METADATA_REF` oder `-- --against <path|url>` |
 | `npm run fdroid:android` | Android Build mit F-Droid Profil (`FDROID_BUILD=1`) |
 | `npm run licenses:generate` | Generiert `THIRD_PARTY_LICENSES.md` aus installierten Paketen |
 | `npm run licenses:check` | Prueft, dass `THIRD_PARTY_LICENSES.md` aktuell ist |
@@ -192,6 +193,11 @@ Optimierungen fuer schnellere PR-Feedback-Zeiten:
 - F-Droid Config-Checks ausfuehren:
    ```bash
    npm run fdroid:check
+   ```
+- F-Droid Metadaten-Invarianten und optionalen Driftvergleich ausfuehren:
+   ```bash
+   npm run fdroid:metadata:drift
+   FDROID_METADATA_REF="https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/io.github.gametrojaner.geburtstage.yml" npm run fdroid:metadata:drift
    ```
 - F-Droid Android-Build ausfuehren:
    ```bash

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ Aktuell: **150 Tests** in 18 Suites.
 
 Der `auto-version.yml` Workflow nutzt `.github/scripts/bump-version.cjs`, das:
 - `package.json`, `app.json`, `android/app/build.gradle` und die F-Droid YAML aktualisiert.
-- Den bisherigen `HEAD` Eintrag in der F-Droid YAML einfriert.
-- Einen neuen `commit: HEAD` Eintrag für die neue Version erstellt.
+- Legacy-`commit: HEAD` Eintraege (falls vorhanden) auf den vorherigen Tag umstellt.
+- Einen neuen getaggten `commit: v<version>` Eintrag fuer die neue Version erstellt.
+- Sicherstellt, dass der F-Droid Build-Befehl `assembleRelease -Pfdroid.build=true` verwendet.
 
 Optimierungen fuer schnellere PR-Feedback-Zeiten:
 - `ci.yml` und `fdroid-readiness.yml` brechen veraltete Runs derselben Branch automatisch ab (`concurrency`).

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -99,6 +99,14 @@ describe('Developer workflow guards', () => {
     expect(output).toContain('Invariants OK');
   });
 
+  it('fdroid metadata drift script uses URL parsing for protocol selection', () => {
+    const scriptPath = path.join(repoRoot, 'scripts', 'fdroid-metadata-drift.cjs');
+    const content = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(content).toContain('const parsedUrl = new URL(url);');
+    expect(content).toContain("parsedUrl.protocol === 'https:'");
+  });
+
   it('fdroid check scans all relevant dependency sections for forbidden packages', () => {
     const fdroidCheckPath = path.join(repoRoot, 'scripts', 'fdroid-check.cjs');
     const content = fs.readFileSync(fdroidCheckPath, 'utf8');
@@ -151,5 +159,14 @@ describe('Developer workflow guards', () => {
 
     expect(content).not.toContain('commit: HEAD');
     expect(content).toMatch(/-\s+.*assembleRelease.*-Pfdroid\.build=true/m);
+  });
+
+  it('bump-version script writes tagged fdroid commits with fdroid.build flag', () => {
+    const scriptPath = path.join(repoRoot, '.github', 'scripts', 'bump-version.cjs');
+    const content = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(content).toContain('commit: v${newVersion}');
+    expect(content).toContain('assembleRelease -Pfdroid.build=true');
+    expect(content).not.toContain('`    commit: HEAD`,');
   });
 });

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -105,6 +105,16 @@ describe('Developer workflow guards', () => {
 
     expect(content).toContain('const parsedUrl = new URL(url);');
     expect(content).toContain("parsedUrl.protocol === 'https:'");
+    expect(content).toContain("parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:'");
+    expect(content).toContain('REQUEST_TIMEOUT_MS = 15000');
+    expect(content).toContain('MAX_RESPONSE_BYTES = 1024 * 1024');
+  });
+
+  it('fdroid metadata drift invariant only flags actual commit HEAD lines', () => {
+    const scriptPath = path.join(repoRoot, 'scripts', 'fdroid-metadata-drift.cjs');
+    const content = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(content).toContain('const disallowedCommitPattern = /^(?!\\s*#)\\s*commit:\\s*HEAD\\s*(?:#.*)?$/m;');
   });
 
   it('fdroid check scans all relevant dependency sections for forbidden packages', () => {

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -48,6 +48,7 @@ describe('Developer workflow guards', () => {
     const packageJsonPath = path.join(repoRoot, 'package.json');
     const packageJson = fs.readFileSync(packageJsonPath, 'utf8');
     expect(packageJson).toContain('fdroid:check');
+    expect(packageJson).toContain('fdroid:metadata:drift');
     expect(packageJson).toContain('fdroid:android');
     expect(packageJson).toContain('-Pfdroid.build=true');
     expect(packageJson).toContain('licenses:generate');
@@ -89,6 +90,15 @@ describe('Developer workflow guards', () => {
     expect(output).toContain('[fdroid-check] All checks passed.');
   });
 
+  it('runs fdroid metadata drift invariant check successfully', () => {
+    const output = execFileSync('node', ['scripts/fdroid-metadata-drift.cjs'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+
+    expect(output).toContain('Invariants OK');
+  });
+
   it('fdroid check scans all relevant dependency sections for forbidden packages', () => {
     const fdroidCheckPath = path.join(repoRoot, 'scripts', 'fdroid-check.cjs');
     const content = fs.readFileSync(fdroidCheckPath, 'utf8');
@@ -128,5 +138,30 @@ describe('Developer workflow guards', () => {
       /if\s*\(\s*findProperty\('fdroid\.build'\)\s*==\s*'true'\s*\)\s*\{[\s\S]*?configurations\.configureEach\s*\{[\s\S]*?exclude group: 'com\.google\.firebase'[\s\S]*?exclude group: 'com\.google\.android\.gms'[\s\S]*?exclude group: 'com\.android\.installreferrer'[\s\S]*?\}[\s\S]*?\}/m;
 
     expect(content).toMatch(guardedExclusionBlockRegex);
+  });
+
+  it('fdroid metadata uses tagged commits and fdroid.build flag for release builds', () => {
+    const metadataPath = path.join(
+      repoRoot,
+      'fdroid',
+      'metadata',
+      'io.github.gametrojaner.geburtstage.yml'
+    );
+    const content = fs.readFileSync(metadataPath, 'utf8');
+
+    expect(content).not.toContain('commit: HEAD');
+
+    const commandEntries = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('- '))
+      .map((line) => line.slice(2));
+
+    const assembleReleaseCommands = commandEntries.filter((line) => line.includes('assembleRelease'));
+
+    expect(assembleReleaseCommands.length).toBeGreaterThan(0);
+    for (const line of assembleReleaseCommands) {
+      expect(line).toContain('-Pfdroid.build=true');
+    }
   });
 });

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -150,18 +150,6 @@ describe('Developer workflow guards', () => {
     const content = fs.readFileSync(metadataPath, 'utf8');
 
     expect(content).not.toContain('commit: HEAD');
-
-    const commandEntries = content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith('- '))
-      .map((line) => line.slice(2));
-
-    const assembleReleaseCommands = commandEntries.filter((line) => line.includes('assembleRelease'));
-
-    expect(assembleReleaseCommands.length).toBeGreaterThan(0);
-    for (const line of assembleReleaseCommands) {
-      expect(line).toContain('-Pfdroid.build=true');
-    }
+    expect(content).toMatch(/-\s+.*assembleRelease.*-Pfdroid\.build=true/m);
   });
 });

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -110,6 +110,16 @@ describe('Developer workflow guards', () => {
     expect(content).toContain('MAX_RESPONSE_BYTES = 1024 * 1024');
   });
 
+  it('fdroid metadata drift script handles response stream errors without double-settling', () => {
+    const scriptPath = path.join(repoRoot, 'scripts', 'fdroid-metadata-drift.cjs');
+    const content = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(content).toContain("response.on('error', rejectOnce);");
+    expect(content).toContain('let isSettled = false;');
+    expect(content).toContain('const rejectOnce = (error) => {');
+    expect(content).toContain('const resolveOnce = (value) => {');
+  });
+
   it('fdroid metadata drift invariant only flags actual commit HEAD lines', () => {
     const scriptPath = path.join(repoRoot, 'scripts', 'fdroid-metadata-drift.cjs');
     const content = fs.readFileSync(scriptPath, 'utf8');

--- a/fdroid/metadata/io.github.gametrojaner.geburtstage.yml
+++ b/fdroid/metadata/io.github.gametrojaner.geburtstage.yml
@@ -37,7 +37,7 @@ Builds:
       - npm ci --legacy-peer-deps
     build:
       - npm run fdroid:check
-      - cd android && ./gradlew assembleRelease
+      - cd android && ./gradlew assembleRelease -Pfdroid.build=true
 
   - versionName: 1.0.0-beta.3
     versionCode: 2
@@ -50,7 +50,7 @@ Builds:
       - npm ci --legacy-peer-deps
     build:
       - npm run fdroid:check
-      - cd android && ./gradlew assembleRelease
+      - cd android && ./gradlew assembleRelease -Pfdroid.build=true
 
   - versionName: 1.0.0-beta.4
     versionCode: 3
@@ -63,7 +63,7 @@ Builds:
       - npm ci --legacy-peer-deps
     build:
       - npm run fdroid:check
-      - cd android && ./gradlew assembleRelease
+      - cd android && ./gradlew assembleRelease -Pfdroid.build=true
 
   - versionName: 1.0.0-beta.5
     versionCode: 4
@@ -93,11 +93,11 @@ Builds:
       - npm ci --legacy-peer-deps
     build:
       - npm run fdroid:check
-      - cd android && ./gradlew assembleRelease
+      - cd android && ./gradlew assembleRelease -Pfdroid.build=true
 
   - versionName: 1.0.0-beta.7
     versionCode: 6
-    commit: HEAD
+    commit: v1.0.0-beta.7
     subdir: .
     sudo:
       - apt-get update
@@ -106,7 +106,7 @@ Builds:
       - npm ci --legacy-peer-deps
     build:
       - npm run fdroid:check
-      - cd android && ./gradlew assembleRelease
+      - cd android && ./gradlew assembleRelease -Pfdroid.build=true
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "fdroid:check": "node scripts/fdroid-check.cjs",
+    "fdroid:metadata:drift": "node scripts/fdroid-metadata-drift.cjs",
     "fdroid:android": "FDROID_BUILD=1 npx expo run:android -- -Pfdroid.build=true",
     "licenses:generate": "node scripts/generate-third-party-licenses.cjs",
     "licenses:check": "npm run licenses:generate && git diff --exit-code THIRD_PARTY_LICENSES.md",

--- a/scripts/fdroid-metadata-drift.cjs
+++ b/scripts/fdroid-metadata-drift.cjs
@@ -14,6 +14,8 @@ const defaultMetadataPath = path.join(
   'io.github.gametrojaner.geburtstage.yml'
 );
 const MAX_REDIRECTS = 10;
+const REQUEST_TIMEOUT_MS = 15000;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
 
 function parseArgs(argv) {
   const options = {
@@ -41,9 +43,14 @@ function parseArgs(argv) {
 function loadUrl(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      reject(new Error(`Failed to fetch ${url} (unsupported protocol ${parsedUrl.protocol})`));
+      return;
+    }
+
     const getter = parsedUrl.protocol === 'https:' ? https : http;
 
-    getter
+    const request = getter
       .get(parsedUrl, (response) => {
         if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
           if (redirectCount >= MAX_REDIRECTS) {
@@ -65,8 +72,15 @@ function loadUrl(url, redirectCount = 0) {
         }
 
         let body = '';
+        let bodySize = 0;
         response.setEncoding('utf8');
         response.on('data', (chunk) => {
+          bodySize += Buffer.byteLength(chunk);
+          if (bodySize > MAX_RESPONSE_BYTES) {
+            response.destroy(new Error(`Failed to fetch ${url} (response too large)`));
+            return;
+          }
+
           body += chunk;
         });
         response.on('end', () => {
@@ -74,6 +88,10 @@ function loadUrl(url, redirectCount = 0) {
         });
       })
       .on('error', reject);
+
+    request.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error(`Failed to fetch ${url} (timed out after ${REQUEST_TIMEOUT_MS}ms)`));
+    });
   });
 }
 
@@ -92,7 +110,8 @@ function normalize(text) {
 }
 
 function assertMetadataInvariants(content) {
-  if (content.includes('commit: HEAD')) {
+  const disallowedCommitPattern = /^(?!\s*#)\s*commit:\s*HEAD\s*(?:#.*)?$/m;
+  if (disallowedCommitPattern.test(content)) {
     throw new Error('Found disallowed commit pin: commit: HEAD');
   }
 

--- a/scripts/fdroid-metadata-drift.cjs
+++ b/scripts/fdroid-metadata-drift.cjs
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
+const { URL } = require('url');
 
 const repoRoot = path.resolve(__dirname, '..');
 const defaultMetadataPath = path.join(
@@ -12,6 +13,7 @@ const defaultMetadataPath = path.join(
   'metadata',
   'io.github.gametrojaner.geburtstage.yml'
 );
+const MAX_REDIRECTS = 10;
 
 function parseArgs(argv) {
   const options = {
@@ -36,18 +38,27 @@ function parseArgs(argv) {
   return options;
 }
 
-function loadUrl(url) {
+function loadUrl(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
     const getter = url.startsWith('https://') ? https : http;
 
     getter
       .get(url, (response) => {
         if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
-          resolve(loadUrl(response.headers.location));
+          if (redirectCount >= MAX_REDIRECTS) {
+            response.resume();
+            reject(new Error(`Failed to fetch ${url} (too many redirects)`));
+            return;
+          }
+
+          const redirectUrl = new URL(response.headers.location, url).toString();
+          response.resume();
+          resolve(loadUrl(redirectUrl, redirectCount + 1));
           return;
         }
 
         if (response.statusCode !== 200) {
+          response.resume();
           reject(new Error(`Failed to fetch ${url} (HTTP ${response.statusCode || 'unknown'})`));
           return;
         }
@@ -128,7 +139,7 @@ async function main() {
 
   const localRaw = fs.readFileSync(defaultMetadataPath, 'utf8');
   assertMetadataInvariants(localRaw);
-  console.log('[fdroid-metadata-drift] Invariants OK (tagged commits + fdroid.build flag).');
+  console.log('[fdroid-metadata-drift] Invariants OK (commit: HEAD disallowed + fdroid.build flag).');
 
   if (!options.against) {
     console.log('[fdroid-metadata-drift] No reference configured. Set FDROID_METADATA_REF or use --against <path|url> for drift comparison.');

--- a/scripts/fdroid-metadata-drift.cjs
+++ b/scripts/fdroid-metadata-drift.cjs
@@ -42,9 +42,27 @@ function parseArgs(argv) {
 
 function loadUrl(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
+    let isSettled = false;
+    const resolveOnce = (value) => {
+      if (isSettled) {
+        return;
+      }
+
+      isSettled = true;
+      resolve(value);
+    };
+    const rejectOnce = (error) => {
+      if (isSettled) {
+        return;
+      }
+
+      isSettled = true;
+      reject(error);
+    };
+
     const parsedUrl = new URL(url);
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-      reject(new Error(`Failed to fetch ${url} (unsupported protocol ${parsedUrl.protocol})`));
+      rejectOnce(new Error(`Failed to fetch ${url} (unsupported protocol ${parsedUrl.protocol})`));
       return;
     }
 
@@ -52,22 +70,24 @@ function loadUrl(url, redirectCount = 0) {
 
     const request = getter
       .get(parsedUrl, (response) => {
+        response.on('error', rejectOnce);
+
         if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
           if (redirectCount >= MAX_REDIRECTS) {
             response.resume();
-            reject(new Error(`Failed to fetch ${url} (too many redirects)`));
+            rejectOnce(new Error(`Failed to fetch ${url} (too many redirects)`));
             return;
           }
 
           const redirectUrl = new URL(response.headers.location, url).toString();
           response.resume();
-          resolve(loadUrl(redirectUrl, redirectCount + 1));
+          resolveOnce(loadUrl(redirectUrl, redirectCount + 1));
           return;
         }
 
         if (response.statusCode !== 200) {
           response.resume();
-          reject(new Error(`Failed to fetch ${url} (HTTP ${response.statusCode || 'unknown'})`));
+          rejectOnce(new Error(`Failed to fetch ${url} (HTTP ${response.statusCode || 'unknown'})`));
           return;
         }
 
@@ -84,10 +104,10 @@ function loadUrl(url, redirectCount = 0) {
           body += chunk;
         });
         response.on('end', () => {
-          resolve(body);
+          resolveOnce(body);
         });
       })
-      .on('error', reject);
+      .on('error', rejectOnce);
 
     request.setTimeout(REQUEST_TIMEOUT_MS, () => {
       request.destroy(new Error(`Failed to fetch ${url} (timed out after ${REQUEST_TIMEOUT_MS}ms)`));

--- a/scripts/fdroid-metadata-drift.cjs
+++ b/scripts/fdroid-metadata-drift.cjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+
+const repoRoot = path.resolve(__dirname, '..');
+const defaultMetadataPath = path.join(
+  repoRoot,
+  'fdroid',
+  'metadata',
+  'io.github.gametrojaner.geburtstage.yml'
+);
+
+function parseArgs(argv) {
+  const options = {
+    against: process.env.FDROID_METADATA_REF,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--against') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --against');
+      }
+      options.against = value;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function loadUrl(url) {
+  return new Promise((resolve, reject) => {
+    const getter = url.startsWith('https://') ? https : http;
+
+    getter
+      .get(url, (response) => {
+        if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+          resolve(loadUrl(response.headers.location));
+          return;
+        }
+
+        if (response.statusCode !== 200) {
+          reject(new Error(`Failed to fetch ${url} (HTTP ${response.statusCode || 'unknown'})`));
+          return;
+        }
+
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          body += chunk;
+        });
+        response.on('end', () => {
+          resolve(body);
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+async function readContent(source) {
+  if (/^https?:\/\//i.test(source)) {
+    return loadUrl(source);
+  }
+
+  const filePath = path.isAbsolute(source) ? source : path.join(repoRoot, source);
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function normalize(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n').map((line) => line.replace(/[ \t]+$/g, ''));
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function assertMetadataInvariants(content) {
+  if (content.includes('commit: HEAD')) {
+    throw new Error('Found disallowed commit pin: commit: HEAD');
+  }
+
+  const commandEntries = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2));
+
+  const assembleReleaseCommands = commandEntries.filter((line) => line.includes('assembleRelease'));
+
+  if (assembleReleaseCommands.length === 0) {
+    throw new Error('No assembleRelease command found in F-Droid metadata draft');
+  }
+
+  for (const command of assembleReleaseCommands) {
+    if (!command.includes('-Pfdroid.build=true')) {
+      throw new Error(`assembleRelease command missing -Pfdroid.build=true: ${command}`);
+    }
+  }
+}
+
+function reportFirstDiff(localContent, referenceContent) {
+  const localLines = localContent.split('\n');
+  const referenceLines = referenceContent.split('\n');
+  const maxLength = Math.max(localLines.length, referenceLines.length);
+
+  for (let i = 0; i < maxLength; i += 1) {
+    const local = localLines[i] || '';
+    const reference = referenceLines[i] || '';
+    if (local !== reference) {
+      return {
+        line: i + 1,
+        local,
+        reference,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const localRaw = fs.readFileSync(defaultMetadataPath, 'utf8');
+  assertMetadataInvariants(localRaw);
+  console.log('[fdroid-metadata-drift] Invariants OK (tagged commits + fdroid.build flag).');
+
+  if (!options.against) {
+    console.log('[fdroid-metadata-drift] No reference configured. Set FDROID_METADATA_REF or use --against <path|url> for drift comparison.');
+    return;
+  }
+
+  const referenceRaw = await readContent(options.against);
+  const localNormalized = normalize(localRaw);
+  const referenceNormalized = normalize(referenceRaw);
+
+  if (localNormalized !== referenceNormalized) {
+    const diff = reportFirstDiff(localNormalized, referenceNormalized);
+    const locationText = diff ? `line ${diff.line}` : 'unknown location';
+    const localLine = diff ? diff.local : '(n/a)';
+    const referenceLine = diff ? diff.reference : '(n/a)';
+
+    throw new Error(
+      [
+        `Metadata drift detected against ${options.against} (${locationText}).`,
+        `local:     ${localLine}`,
+        `reference: ${referenceLine}`,
+      ].join('\n')
+    );
+  }
+
+  console.log(`[fdroid-metadata-drift] No drift detected against ${options.against}.`);
+}
+
+main().catch((error) => {
+  console.error(`[fdroid-metadata-drift] ERROR: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/fdroid-metadata-drift.cjs
+++ b/scripts/fdroid-metadata-drift.cjs
@@ -40,10 +40,11 @@ function parseArgs(argv) {
 
 function loadUrl(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
-    const getter = url.startsWith('https://') ? https : http;
+    const parsedUrl = new URL(url);
+    const getter = parsedUrl.protocol === 'https:' ? https : http;
 
     getter
-      .get(url, (response) => {
+      .get(parsedUrl, (response) => {
         if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
           if (redirectCount >= MAX_REDIRECTS) {
             response.resume();


### PR DESCRIPTION
## Ziel
Dieser PR macht den F-Droid-Metadaten-Workflow robuster und reduziert Drift zwischen lokalem Entwurf und Referenz-Metadaten.

## Was wurde umgesetzt
- Neues Script: scripts/fdroid-metadata-drift.cjs
  - Prüft Invarianten der lokalen F-Droid-Metadaten:
    - kein `commit: HEAD`
    - `assembleRelease`-Kommandos enthalten `-Pfdroid.build=true`
  - Optionaler Drift-Vergleich gegen Referenz via:
    - Umgebungsvariable `FDROID_METADATA_REF`
    - oder `--against <path|url>`
- Neues npm-Command:
  - `npm run fdroid:metadata:drift`
- Tests erweitert in __tests__/dev-workflow.test.ts:
  - Validiert, dass das neue npm-Command vorhanden ist
  - Führt den Invariant-Check aus
  - Zusätzliche Metadaten-Guard-Assertion bleibt vorhanden
- Doku aktualisiert:
  - README um den neuen Command inkl. Referenz-Beispiel erweitert
  - PROJECT_CONTEXT um Workflow-Hinweis ergänzt

## Wann läuft das Script?
- Nicht als eigener separater CI-Step.
- Automatisch indirekt über den Testlauf (`npm test`), weil der Workflow-Test das Script aufruft.
- Manuell empfohlen vor F-Droid-Metadaten-Änderungen und vor fdroiddata-Submission:
  - `npm run fdroid:metadata:drift`
  - optional mit Referenzvergleich, z.B.:
    - `FDROID_METADATA_REF="https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/io.github.gametrojaner.geburtstage.yml" npm run fdroid:metadata:drift`

## Review-Findings
Die im PR gemeldeten Findings wurden adressiert:
- Redirect-Handling im Script robust gemacht (relative Redirects + Redirect-Limit + Response-Drain).
- Invariant-Logtext präzisiert (entspricht exakt der tatsächlich geprüften Regel).
- Doppelte Parsing-Logik im Test reduziert.

## Warum das wichtig ist
- Verhindert stille Regressionen in der Metadaten-Datei vor einer fdroiddata-Submission.
- Macht Abweichungen zur gewünschten Referenz früh sichtbar.
- Senkt das Risiko für Scanner-/Build-Probleme durch fehlende `-Pfdroid.build=true` Flags.

## Validierung
Lokal ausgeführt:
- npm run test:typecheck
- npm test -- --runInBand

Ergebnis:
- Typecheck erfolgreich
- 18/18 Test Suites erfolgreich
- 152/152 Tests erfolgreich

## Nutzer-Auswirkung
Keine funktionale Änderung für Endnutzer in der App. Änderungen betreffen Developer-Workflow, Qualitätssicherung und Release-Vorbereitung.
