### PR TITLE
F-Droid: Scanner-Fix fuer transitive proprietaere APK-Dependencies

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -173,7 +173,7 @@ Reagiert auf: WIDGET_ADDED, WIDGET_UPDATE, WIDGET_RESIZED.
 - **jest.config.js**: Nutzt `babel-jest` direkt (nicht jest-expo preset) wegen Kompatibilität mit Expo SDK 55
 - **react-native-worklets**: Wird von reanimated 4.x babel plugin benötigt, muss installiert sein
 - **F-Droid Profil**: `FDROID_BUILD=1` aktiviert die dedizierte Expo-Konfiguration aus `app.config.js` (OTA disabled, Notifications-Modus `local-only`); validierbar via `npm run fdroid:check`
-- **F-Droid Dependency-Hardening**: `npm run fdroid:check` prueft nicht nur `compileOnly` in den gepatchten Expo-Gradle-Files, sondern auch die Expo `local-maven-repo` Metadaten (`.pom` / `.module`), damit Firebase/InstallReferrer nicht mehr transitiv als Runtime-Dependency aufgeloest werden.
+- **F-Droid Dependency-Hardening**: `npm run fdroid:check` prueft nicht nur `compileOnly` in den gepatchten Expo-Gradle-Files, sondern auch die Expo `local-maven-repo` Metadaten (`.pom` / `.module`), damit Firebase/Play-Services-Tasks/InstallReferrer nicht mehr transitiv als Runtime-Dependency aufgeloest werden.
 - **F-Droid JDK**: `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` nutzt `openjdk-21-jdk` fuer Konsistenz mit fdroiddata-CI
 - **Lizenz**: Projekt ist `GPL-3.0-or-later` (`LICENSE`); Metadaten in `package.json` und `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` synchron halten
 - **Patentpolitik**: Contributor Non-Assertion via `PATENTS.md`; Beitragspfad in `CONTRIBUTING.md`

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -173,6 +173,7 @@ Reagiert auf: WIDGET_ADDED, WIDGET_UPDATE, WIDGET_RESIZED.
 - **jest.config.js**: Nutzt `babel-jest` direkt (nicht jest-expo preset) wegen Kompatibilität mit Expo SDK 55
 - **react-native-worklets**: Wird von reanimated 4.x babel plugin benötigt, muss installiert sein
 - **F-Droid Profil**: `FDROID_BUILD=1` aktiviert die dedizierte Expo-Konfiguration aus `app.config.js` (OTA disabled, Notifications-Modus `local-only`); validierbar via `npm run fdroid:check`
+- **F-Droid Dependency-Hardening**: `npm run fdroid:check` prueft nicht nur `compileOnly` in den gepatchten Expo-Gradle-Files, sondern auch die Expo `local-maven-repo` Metadaten (`.pom` / `.module`), damit Firebase/InstallReferrer nicht mehr transitiv als Runtime-Dependency aufgeloest werden.
 - **F-Droid JDK**: `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` nutzt `openjdk-21-jdk` fuer Konsistenz mit fdroiddata-CI
 - **Lizenz**: Projekt ist `GPL-3.0-or-later` (`LICENSE`); Metadaten in `package.json` und `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` synchron halten
 - **Patentpolitik**: Contributor Non-Assertion via `PATENTS.md`; Beitragspfad in `CONTRIBUTING.md`

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Optimierungen fuer schnellere PR-Feedback-Zeiten:
    ```bash
    npm run fdroid:check
    ```
+  Der Check validiert dabei sowohl die gepatchten Gradle-Abhaengigkeiten (`compileOnly`) als auch die
+  Expo `local-maven-repo` Metadaten (`.pom`/`.module`), damit keine proprietaeren Runtime-Dependencies
+  (Firebase / Play-Services-Tasks / Install Referrer) wieder transitiv ins APK gelangen.
 - F-Droid Android-Build ausfuehren:
    ```bash
    npm run fdroid:android

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -105,8 +105,13 @@ describe('Developer workflow guards', () => {
 
     expect(content).toContain('node_modules/expo-notifications/android/build.gradle');
     expect(content).toContain('node_modules/expo-application/android/build.gradle');
+    expect(content).toContain('expo.modules.notifications-55.0.14.pom');
+    expect(content).toContain('expo.modules.notifications-55.0.14.module');
+    expect(content).toContain('expo.modules.application-55.0.10.pom');
+    expect(content).toContain('expo.modules.application-55.0.10.module');
     expect(content).toContain('compileOnlyRegex');
     expect(content).toContain('implementationRegex');
+    expect(content).toContain('local-Maven metadata is free of proprietary runtime dependencies');
     expect(content).toContain("checkAutomatically must be 'NEVER'");
     expect(content).toContain('fallbackToCacheTimeout must be 0');
   });

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -109,6 +109,8 @@ describe('Developer workflow guards', () => {
     expect(content).toContain('expo.modules.notifications-55.0.14.module');
     expect(content).toContain('expo.modules.application-55.0.10.pom');
     expect(content).toContain('expo.modules.application-55.0.10.module');
+    expect(content).toContain('com\\.google\\.android\\.gms');
+    expect(content).toContain('play-services-tasks');
     expect(content).toContain('compileOnlyRegex');
     expect(content).toContain('implementationRegex');
     expect(content).toContain('local-Maven metadata is free of proprietary runtime dependencies');

--- a/patches/expo-application+55.0.10.patch
+++ b/patches/expo-application+55.0.10.patch
@@ -13,23 +13,23 @@ index f69c5ba..ab67686 100644
    if (project.findProject(':expo-modules-test-core')) {
      testImplementation project(':expo-modules-test-core')
 diff --git a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
-index bf59fcd..8895a7f 100644
+index bf59fcd..7da4938 100644
 --- a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
 +++ b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
-@@ -50,13 +50,6 @@
+@@ -49,13 +49,6 @@
+           "version": {
              "requires": "2.1.20"
            }
-         },
+-        },
 -        {
 -          "group": "com.android.installreferrer",
 -          "module": "installreferrer",
 -          "version": {
 -            "requires": "2.2"
 -          }
--        }
+         }
        ],
        "files": [
-         {
 diff --git a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom
 index 4046065..5a9e895 100644
 --- a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom

--- a/patches/expo-application+55.0.10.patch
+++ b/patches/expo-application+55.0.10.patch
@@ -12,3 +12,37 @@ index f69c5ba..ab67686 100644
  
    if (project.findProject(':expo-modules-test-core')) {
      testImplementation project(':expo-modules-test-core')
+diff --git a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
+index bf59fcd..8895a7f 100644
+--- a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
++++ b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module
+@@ -50,13 +50,6 @@
+             "requires": "2.1.20"
+           }
+         },
+-        {
+-          "group": "com.android.installreferrer",
+-          "module": "installreferrer",
+-          "version": {
+-            "requires": "2.2"
+-          }
+-        }
+       ],
+       "files": [
+         {
+diff --git a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom
+index 4046065..5a9e895 100644
+--- a/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom
++++ b/node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom
+@@ -43,11 +43,5 @@
+       <version>2.1.20</version>
+       <scope>runtime</scope>
+     </dependency>
+-    <dependency>
+-      <groupId>com.android.installreferrer</groupId>
+-      <artifactId>installreferrer</artifactId>
+-      <version>2.2</version>
+-      <scope>runtime</scope>
+-    </dependency>
+   </dependencies>
+ </project>

--- a/patches/expo-notifications+55.0.14.patch
+++ b/patches/expo-notifications+55.0.14.patch
@@ -12,3 +12,38 @@ index 38959e0..f91d8f9 100644
  
    implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
  
+diff --git a/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module b/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module
+index e0e524a..f8a1563 100644
+--- a/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module
++++ b/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module
+@@ -92,13 +92,6 @@
+             "requires": "1.10.2"
+           }
+         },
+-        {
+-          "group": "com.google.firebase",
+-          "module": "firebase-messaging",
+-          "version": {
+-            "requires": "25.0.1"
+-          }
+-        },
+         {
+           "group": "me.leolin",
+           "module": "ShortcutBadger",
+diff --git a/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom b/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom
+index 084a4d3..4fb28cd 100644
+--- a/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom
++++ b/node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom
+@@ -79,12 +79,6 @@
+       <version>1.10.2</version>
+       <scope>runtime</scope>
+     </dependency>
+-    <dependency>
+-      <groupId>com.google.firebase</groupId>
+-      <artifactId>firebase-messaging</artifactId>
+-      <version>25.0.1</version>
+-      <scope>runtime</scope>
+-    </dependency>
+     <dependency>
+       <groupId>me.leolin</groupId>
+       <artifactId>ShortcutBadger</artifactId>

--- a/scripts/fdroid-check.cjs
+++ b/scripts/fdroid-check.cjs
@@ -165,6 +165,43 @@ for (const { file, artifact } of installedGradleChecks) {
 }
 pass('Installed expo module Gradle files use compileOnly for proprietary artifacts.');
 
+// 7c. Installed local Maven metadata must not reintroduce proprietary runtime deps.
+const localMavenMetadataChecks = [
+  {
+    file: 'node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom',
+    forbidden: [/com\.google\.firebase/, /firebase-messaging/],
+  },
+  {
+    file: 'node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module',
+    forbidden: [/"group"\s*:\s*"com\.google\.firebase"/, /"module"\s*:\s*"firebase-messaging"/],
+  },
+  {
+    file: 'node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom',
+    forbidden: [/com\.android\.installreferrer/, /installreferrer/],
+  },
+  {
+    file: 'node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.module',
+    forbidden: [/"group"\s*:\s*"com\.android\.installreferrer"/, /"module"\s*:\s*"installreferrer"/],
+  },
+];
+
+for (const { file, forbidden } of localMavenMetadataChecks) {
+  const metadataPath = path.join(ROOT, file);
+  if (!fs.existsSync(metadataPath)) {
+    fail(
+      `Missing ${file}. Run 'npm ci --legacy-peer-deps' so local Maven metadata is present before running fdroid:check.`
+    );
+  }
+
+  const content = fs.readFileSync(metadataPath, 'utf8');
+  for (const pattern of forbidden) {
+    if (pattern.test(content)) {
+      fail(`${file} must not declare proprietary runtime dependency '${pattern.source}'.`);
+    }
+  }
+}
+pass('Installed expo module local-Maven metadata is free of proprietary runtime dependencies.');
+
 // 8. AndroidManifest.xml must not reference Firebase meta-data keys
 const manifestPath = path.join(ROOT, 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
 const manifestContent = fs.readFileSync(manifestPath, 'utf8');

--- a/scripts/fdroid-check.cjs
+++ b/scripts/fdroid-check.cjs
@@ -169,11 +169,21 @@ pass('Installed expo module Gradle files use compileOnly for proprietary artifac
 const localMavenMetadataChecks = [
   {
     file: 'node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.pom',
-    forbidden: [/com\.google\.firebase/, /firebase-messaging/],
+    forbidden: [
+      /com\.google\.firebase/,
+      /firebase-messaging/,
+      /com\.google\.android\.gms/,
+      /play-services-tasks/,
+    ],
   },
   {
     file: 'node_modules/expo-notifications/local-maven-repo/host/exp/exponent/expo.modules.notifications/55.0.14/expo.modules.notifications-55.0.14.module',
-    forbidden: [/"group"\s*:\s*"com\.google\.firebase"/, /"module"\s*:\s*"firebase-messaging"/],
+    forbidden: [
+      /"group"\s*:\s*"com\.google\.firebase"/,
+      /"module"\s*:\s*"firebase-messaging"/,
+      /"group"\s*:\s*"com\.google\.android\.gms"/,
+      /"module"\s*:\s*"play-services-tasks"/,
+    ],
   },
   {
     file: 'node_modules/expo-application/local-maven-repo/host/exp/exponent/expo.modules.application/55.0.10/expo.modules.application-55.0.10.pom',


### PR DESCRIPTION
## Ziel
Dieser PR behebt den verbleibenden F-Droid-Blocker aus check apk: proprietaere Klassen (Firebase/GMS Tasks/Install Referrer) waren trotz -Pfdroid.build=true weiterhin im finalen APK enthalten.

## Ursache
Die bisherigen Patches haben zwar implementation -> compileOnly in den Expo-Gradle-Dateien umgestellt, aber die Expo local-maven-repo Metadaten (.pom / .module) enthielten weiterhin Runtime-Dependencies auf proprietaere Artefakte.

## Aenderungen
1. patches/expo-notifications+55.0.14.patch erweitert:
- entfernt firebase-messaging auch aus
- expo.modules.notifications-55.0.14.pom
- expo.modules.notifications-55.0.14.module

2. patches/expo-application+55.0.10.patch erweitert:
- entfernt installreferrer auch aus
- expo.modules.application-55.0.10.pom
- expo.modules.application-55.0.10.module

3. scripts/fdroid-check.cjs gehaertet:
- prueft zusaetzlich, dass die installierten Expo local-maven-repo Metadaten keine proprietaeren Runtime-Dependencies mehr deklarieren.

4. Tests/Doku aktualisiert:
- __tests__/dev-workflow.test.ts um neue Guard-Pruefungen erweitert.
- README.md und PROJECT_CONTEXT.md mit Hinweis auf die neue local-Maven-Validierung aktualisiert.

## Validierung
- npm run test:typecheck
- npm test -- --runInBand
- node scripts/fdroid-check.cjs

Alle Checks lokal gruen.

## Kontext: Findings-Status
Die offenen Copilot-Findings auf PR #8 wurden vorab durchgegangen und als erledigt/geschlossen markiert; dieser PR ist der separate technische Fix fuer den check apk-Blocker.