### PR TITLE
fix(fdroid): add expo-application dependency for patching

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -11,6 +11,7 @@ Generated from installed package metadata.
 | @react-navigation/native | 7.2.1 | MIT | [link](https://reactnavigation.org) |
 | @react-navigation/native-stack | 7.14.9 | MIT | [link](https://github.com/software-mansion/react-native-screens#readme) |
 | expo | 55.0.9 | MIT | [link](https://github.com/expo/expo/tree/main/packages/expo) |
+| expo-application | 55.0.10 | MIT | [link](https://docs.expo.dev/versions/latest/sdk/application/) |
 | expo-contacts | 55.0.9 | MIT | [link](https://docs.expo.dev/versions/latest/sdk/contacts/) |
 | expo-document-picker | 55.0.9 | MIT | [link](https://docs.expo.dev/versions/latest/sdk/document-picker/) |
 | expo-file-system | 55.0.12 | MIT | [link](https://docs.expo.dev/versions/latest/sdk/filesystem/) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geburtstage",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geburtstage",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.9",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.2.1",
         "@react-navigation/native-stack": "^7.14.9",
         "expo": "~55.0.9",
+        "expo-application": "~55.0.10",
         "expo-contacts": "~55.0.9",
         "expo-document-picker": "~55.0.9",
         "expo-file-system": "~55.0.12",
@@ -3355,7 +3356,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4581,7 +4582,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -11831,7 +11832,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@react-navigation/native": "^7.2.1",
     "@react-navigation/native-stack": "^7.14.9",
     "expo": "~55.0.9",
+    "expo-application": "~55.0.10",
     "expo-contacts": "~55.0.9",
     "expo-document-picker": "~55.0.9",
     "expo-file-system": "~55.0.12",


### PR DESCRIPTION
## Summary
- add expo-application (~55.0.10) to dependencies
- ensure patch-package reliably applies the existing F-Droid installreferrer patch
- keep proprietary installreferrer/firebase artifacts out of runtime packaging

## Validation
- npm run test:typecheck
- npm test -- --runInBand
- npm run fdroid:check