### PR TITLE
fix(fdroid): sanitize expo-notifications AAR for scanner compliance

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -174,6 +174,7 @@ Reagiert auf: WIDGET_ADDED, WIDGET_UPDATE, WIDGET_RESIZED.
 - **react-native-worklets**: Wird von reanimated 4.x babel plugin benötigt, muss installiert sein
 - **F-Droid Profil**: `FDROID_BUILD=1` aktiviert die dedizierte Expo-Konfiguration aus `app.config.js` (OTA disabled, Notifications-Modus `local-only`); validierbar via `npm run fdroid:check`
 - **F-Droid Dependency-Hardening**: `npm run fdroid:check` prueft nicht nur `compileOnly` in den gepatchten Expo-Gradle-Files, sondern auch die Expo `local-maven-repo` Metadaten (`.pom` / `.module`), damit Firebase/Play-Services-Tasks/InstallReferrer nicht mehr transitiv als Runtime-Dependency aufgeloest werden.
+- **F-Droid AAR-Hardening**: `postinstall` fuehrt `scripts/strip-firebase-aar.cjs` aus und entfernt Firebase-gekoppelte Klassen sowie den FCM-Service aus `expo.modules.notifications-55.0.14.aar`, damit keine Firebase-Typreferenzen im finalen APK-DEX landen.
 - **F-Droid JDK**: `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` nutzt `openjdk-21-jdk` fuer Konsistenz mit fdroiddata-CI
 - **Lizenz**: Projekt ist `GPL-3.0-or-later` (`LICENSE`); Metadaten in `package.json` und `fdroid/metadata/io.github.gametrojaner.geburtstage.yml` synchron halten
 - **Patentpolitik**: Contributor Non-Assertion via `PATENTS.md`; Beitragspfad in `CONTRIBUTING.md`

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Optimierungen fuer schnellere PR-Feedback-Zeiten:
   Der Check validiert dabei sowohl die gepatchten Gradle-Abhaengigkeiten (`compileOnly`) als auch die
   Expo `local-maven-repo` Metadaten (`.pom`/`.module`), damit keine proprietaeren Runtime-Dependencies
   (Firebase / Play-Services-Tasks / Install Referrer) wieder transitiv ins APK gelangen.
+   Zusaetzlich entfernt `postinstall` per `scripts/strip-firebase-aar.cjs` Firebase-gekoppelte Klassen
+   und den FCM-Service aus dem `expo-notifications` AAR, damit keine Firebase-Typreferenzen im finalen
+   DEX verbleiben.
 - F-Droid Android-Build ausfuehren:
    ```bash
    npm run fdroid:android

--- a/__tests__/dev-workflow.test.ts
+++ b/__tests__/dev-workflow.test.ts
@@ -149,11 +149,29 @@ describe('Developer workflow guards', () => {
     expect(content).toContain('expo.modules.application-55.0.10.module');
     expect(content).toContain('com\\.google\\.android\\.gms');
     expect(content).toContain('play-services-tasks');
+    expect(content).toContain('strip-firebase-aar.cjs');
     expect(content).toContain('compileOnlyRegex');
     expect(content).toContain('implementationRegex');
     expect(content).toContain('local-Maven metadata is free of proprietary runtime dependencies');
     expect(content).toContain("checkAutomatically must be 'NEVER'");
     expect(content).toContain('fallbackToCacheTimeout must be 0');
+  });
+
+  it('postinstall and strip script enforce firebase class stripping in expo-notifications AAR', () => {
+    const packageJsonPath = path.join(repoRoot, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    expect(packageJson.scripts?.postinstall).toContain('patch-package');
+    expect(packageJson.scripts?.postinstall).toContain('strip-firebase-aar.cjs');
+
+    const stripScriptPath = path.join(repoRoot, 'scripts', 'strip-firebase-aar.cjs');
+    const stripScript = fs.readFileSync(stripScriptPath, 'utf8');
+
+    expect(stripScript).toContain('expo.modules.notifications-55.0.14.aar');
+    expect(stripScript).toContain('ExpoFirebaseMessagingService.class');
+    expect(stripScript).toContain('FirebaseMessagingDelegate.class');
+    expect(stripScript).toContain('FirebaseNotificationTrigger.class');
+    expect(stripScript).toContain('com\\.google\\.firebase\\.MESSAGING_EVENT');
   });
 
   it('fdroid check rejects proprietary google services gradle plugins', () => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fdroid:android": "FDROID_BUILD=1 npx expo run:android -- -Pfdroid.build=true",
     "licenses:generate": "node scripts/generate-third-party-licenses.cjs",
     "licenses:check": "npm run licenses:generate && git diff --exit-code THIRD_PARTY_LICENSES.md",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && node scripts/strip-firebase-aar.cjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",

--- a/scripts/fdroid-check.cjs
+++ b/scripts/fdroid-check.cjs
@@ -91,6 +91,18 @@ if (forbiddenPkgs.length > 0) {
 }
 pass('No Firebase or GMS packages in package.json.');
 
+// 6b. postinstall must run patch-package and strip Firebase-linked classes from expo-notifications AAR.
+const postinstallScript = packageJson.scripts?.postinstall || '';
+if (!/patch-package/.test(postinstallScript)) {
+  fail("package.json scripts.postinstall must execute patch-package.");
+}
+if (!/strip-firebase-aar\.cjs/.test(postinstallScript)) {
+  fail(
+    "package.json scripts.postinstall must execute scripts/strip-firebase-aar.cjs so expo-notifications AAR is sanitized for F-Droid."
+  );
+}
+pass('postinstall runs patch-package and strips Firebase-linked expo-notifications AAR classes.');
+
 // 7. Patches must exist to exclude Firebase/GMS/installreferrer from the APK
 const requiredPatches = [
   {

--- a/scripts/strip-firebase-aar.cjs
+++ b/scripts/strip-firebase-aar.cjs
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const TARGET_AAR = path.join(
+  ROOT,
+  'node_modules',
+  'expo-notifications',
+  'local-maven-repo',
+  'host',
+  'exp',
+  'exponent',
+  'expo.modules.notifications',
+  '55.0.14',
+  'expo.modules.notifications-55.0.14.aar'
+);
+
+const FIREBASE_CLASS_FILES = [
+  'expo/modules/notifications/service/ExpoFirebaseMessagingService.class',
+  'expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.class',
+  'expo/modules/notifications/service/delegates/FirebaseMessagingDelegate$Companion.class',
+  'expo/modules/notifications/service/interfaces/FirebaseMessagingDelegate.class',
+  'expo/modules/notifications/tokens/interfaces/FirebaseTokenListener.class',
+  'expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.class',
+  'expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger$Companion.class',
+  'expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger$Companion$CREATOR$1.class',
+];
+
+function log(message) {
+  console.log(`[strip-firebase-aar] ${message}`);
+}
+
+function fail(message) {
+  console.error(`[strip-firebase-aar] FAIL: ${message}`);
+  process.exit(1);
+}
+
+function runJar(args, cwd) {
+  const result = spawnSync('jar', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      return { missing: true, stdout: '', stderr: '' };
+    }
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `jar exited with code ${result.status}`);
+  }
+
+  return { missing: false, stdout: result.stdout, stderr: result.stderr };
+}
+
+function removeFirebaseServiceFromManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) {
+    fail(`Missing AndroidManifest.xml in extracted AAR: ${manifestPath}`);
+  }
+
+  const content = fs.readFileSync(manifestPath, 'utf8');
+
+  const serviceRegex =
+    /\s*<service[\s\S]*?android:name="expo\.modules\.notifications\.service\.ExpoFirebaseMessagingService"[\s\S]*?<\/service>\s*/m;
+
+  const cleaned = content
+    .replace(serviceRegex, '\n')
+    .replace(/\s*<action android:name="com\.google\.firebase\.MESSAGING_EVENT"\s*\/>\s*/g, '\n');
+
+  if (cleaned !== content) {
+    fs.writeFileSync(manifestPath, cleaned, 'utf8');
+    return true;
+  }
+
+  return false;
+}
+
+function removeFirebaseClasses(classesRoot) {
+  let removedCount = 0;
+
+  for (const classFile of FIREBASE_CLASS_FILES) {
+    const fullPath = path.join(classesRoot, classFile);
+    if (fs.existsSync(fullPath)) {
+      fs.rmSync(fullPath, { force: true });
+      removedCount += 1;
+    }
+  }
+
+  return removedCount;
+}
+
+function main() {
+  if (!fs.existsSync(TARGET_AAR)) {
+    log('expo-notifications AAR not found, skipping strip step.');
+    return;
+  }
+
+  const probe = runJar(['--help'], ROOT);
+  if (probe.missing) {
+    log("'jar' command not found in PATH, skipping AAR strip step.");
+    return;
+  }
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'strip-firebase-aar-'));
+  const extractedAarDir = path.join(tmpRoot, 'aar');
+  const classesDir = path.join(tmpRoot, 'classes');
+  const repackedAar = path.join(tmpRoot, 'expo.modules.notifications-55.0.14.aar');
+
+  fs.mkdirSync(extractedAarDir, { recursive: true });
+  fs.mkdirSync(classesDir, { recursive: true });
+
+  try {
+    runJar(['xf', TARGET_AAR], extractedAarDir);
+
+    const classesJarPath = path.join(extractedAarDir, 'classes.jar');
+    if (!fs.existsSync(classesJarPath)) {
+      fail(`Missing classes.jar in AAR: ${TARGET_AAR}`);
+    }
+
+    runJar(['xf', classesJarPath], classesDir);
+
+    const removedClassCount = removeFirebaseClasses(classesDir);
+    const manifestChanged = removeFirebaseServiceFromManifest(
+      path.join(extractedAarDir, 'AndroidManifest.xml')
+    );
+
+    fs.rmSync(classesJarPath, { force: true });
+    runJar(['cf', classesJarPath, '-C', classesDir, '.'], extractedAarDir);
+
+    fs.rmSync(classesDir, { recursive: true, force: true });
+    runJar(['cf', repackedAar, '-C', extractedAarDir, '.'], tmpRoot);
+
+    fs.copyFileSync(repackedAar, TARGET_AAR);
+
+    log(
+      `AAR sanitized (removed ${removedClassCount} Firebase class file(s), manifestChanged=${manifestChanged}).`
+    );
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary\n- add postinstall AAR sanitizer to strip Firebase-linked classes from expo-notifications AAR\n- enforce sanitizer presence in fdroid checks and workflow tests\n- update README and PROJECT_CONTEXT with the new hardening step\n\n## Validation\n- npm run test:typecheck\n- npm test -- --runInBand --silent\n- npm run fdroid:check