### PR TITLE
fix(contacts): resolve first-launch permission grant not taking effect

### DIFF
--- a/__tests__/contacts.test.ts
+++ b/__tests__/contacts.test.ts
@@ -11,6 +11,10 @@ import {
   checkContactsPermission,
 } from '../src/services/contacts';
 
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+}));
+
 // Mock expo-contacts
 jest.mock('expo-contacts', () => ({
   Fields: {
@@ -587,6 +591,22 @@ describe('Contact Services', () => {
       expect(result).toBe(true);
       expect(Contacts.requestPermissionsAsync).toHaveBeenCalledTimes(1);
       expect(Contacts.getPermissionsAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false on non-Android without calling getPermissionsAsync', async () => {
+      const rn = require('react-native');
+      const originalOs = rn.Platform.OS;
+      rn.Platform.OS = 'ios';
+      try {
+        (Contacts.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+
+        const result = await requestContactsPermission();
+
+        expect(result).toBe(false);
+        expect(Contacts.getPermissionsAsync).not.toHaveBeenCalled();
+      } finally {
+        rn.Platform.OS = originalOs;
+      }
     });
   });
 

--- a/__tests__/contacts.test.ts
+++ b/__tests__/contacts.test.ts
@@ -564,14 +564,29 @@ describe('Contact Services', () => {
 
       expect(result).toBe(true);
       expect(Contacts.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(Contacts.getPermissionsAsync).not.toHaveBeenCalled();
     });
 
     it('returns false when Expo Contacts denies permission', async () => {
       (Contacts.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Contacts.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
 
       const result = await requestContactsPermission();
 
       expect(result).toBe(false);
+    });
+
+    it('returns true via fallback check when requestPermissionsAsync returns stale denied status', async () => {
+      // Android sometimes propagates the grant after the dialog resolves.
+      // requestPermissionsAsync returns 'denied' but getPermissionsAsync reflects reality.
+      (Contacts.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Contacts.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+
+      const result = await requestContactsPermission();
+
+      expect(result).toBe(true);
+      expect(Contacts.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(Contacts.getPermissionsAsync).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geburtstage",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geburtstage",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.16",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -3355,7 +3355,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4575,7 +4575,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -11807,7 +11807,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -46,6 +46,7 @@ export function HomeScreen() {
   const [snackVisible, setSnackVisible] = useState(false);
   const [lastHidden, setLastHidden] = useState<{ id: string; name: string } | null>(null);
   const [homeFilter, setHomeFilter] = useState<HomeFilter>('all');
+  const [permissionChecked, setPermissionChecked] = useState(false);
   const swipeableRefs = useRef<Map<string, Swipeable | null>>(new Map());
 
   const visibleContacts = useMemo(
@@ -62,6 +63,7 @@ export function HomeScreen() {
     (async () => {
       const granted = await requestContactsPermission();
       setHasContactsPermission(granted);
+      setPermissionChecked(true);
       if (granted) {
         await loadContacts();
         await refreshAllWidgetsNow();
@@ -95,6 +97,10 @@ export function HomeScreen() {
         sections.push({ type: 'contact', contact: c, key: `${group.key}-${c.contactId}` });
       }
     }
+  }
+
+  if (!permissionChecked) {
+    return null;
   }
 
   if (!hasContactsPermission) {

--- a/src/services/contacts.ts
+++ b/src/services/contacts.ts
@@ -10,7 +10,11 @@ export function shouldUseNativeEditorForContact(contactId: string): boolean {
 
 export async function requestContactsPermission(): Promise<boolean> {
   const { status } = await Contacts.requestPermissionsAsync();
-  return status === 'granted';
+  if (status === 'granted') return true;
+  // On Android the OS sometimes hasn't propagated the grant yet when the dialog
+  // promise resolves. A second read from getPermissionsAsync reflects reality.
+  const { status: currentStatus } = await Contacts.getPermissionsAsync();
+  return currentStatus === 'granted';
 }
 
 export async function checkContactsPermission(): Promise<boolean> {

--- a/src/services/contacts.ts
+++ b/src/services/contacts.ts
@@ -1,4 +1,5 @@
 import * as Contacts from 'expo-contacts';
+import { Platform } from 'react-native';
 import { ContactBirthday } from '../types';
 
 const contactsNeedingNativeEditor = new Set<string>();
@@ -13,8 +14,11 @@ export async function requestContactsPermission(): Promise<boolean> {
   if (status === 'granted') return true;
   // On Android the OS sometimes hasn't propagated the grant yet when the dialog
   // promise resolves. A second read from getPermissionsAsync reflects reality.
-  const { status: currentStatus } = await Contacts.getPermissionsAsync();
-  return currentStatus === 'granted';
+  if (Platform.OS === 'android') {
+    const { status: currentStatus } = await Contacts.getPermissionsAsync();
+    return currentStatus === 'granted';
+  }
+  return false;
 }
 
 export async function checkContactsPermission(): Promise<boolean> {


### PR DESCRIPTION
On Android the permission result from requestPermissionsAsync() can still
read as denied right after the user taps Allow, because the OS hasn't
propagated the grant yet when the dialog promise resolves. A second read
via getPermissionsAsync() reflects the actual system state and fixes the
"no access" screen that persisted until app restart.

Also adds a permissionChecked flag in HomeScreen so the "No access" view
is never shown prematurely while the permission check/dialog is still in
flight.

https://claude.ai/code/session_01DvLQ32bAWhJoe1moEuNwzE