### PR TITLE
fix(widget+notifications): exclude hidden contacts from widget and notification scheduling

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -201,6 +201,48 @@ describe('Store - updateSetting', () => {
   });
 });
 
+describe('Store - rescheduleNotifications', () => {
+  it('excludes hidden contacts when scheduling notifications', async () => {
+    const { scheduleAllNotifications } = jest.requireMock('../src/services/notifications') as {
+      scheduleAllNotifications: jest.Mock;
+    };
+
+    useAppStore.setState({
+      contacts: [
+        { contactId: 'c1', name: 'Alice', birthday: { day: 15, month: 4, year: 1990 } },
+        { contactId: 'c2', name: 'Bob (hidden)', birthday: { day: 25, month: 12 } },
+      ],
+      hidden: new Set(['c2']),
+    });
+
+    await useAppStore.getState().rescheduleNotifications();
+
+    expect(scheduleAllNotifications).toHaveBeenCalledTimes(1);
+    const passedContacts = scheduleAllNotifications.mock.calls[0][0] as { contactId: string }[];
+    expect(passedContacts.map(c => c.contactId)).toEqual(['c1']);
+    expect(passedContacts.map(c => c.contactId)).not.toContain('c2');
+  });
+
+  it('passes all contacts when no contacts are hidden', async () => {
+    const { scheduleAllNotifications } = jest.requireMock('../src/services/notifications') as {
+      scheduleAllNotifications: jest.Mock;
+    };
+
+    useAppStore.setState({
+      contacts: [
+        { contactId: 'c1', name: 'Alice', birthday: { day: 15, month: 4, year: 1990 } },
+        { contactId: 'c2', name: 'Bob', birthday: { day: 25, month: 12 } },
+      ],
+      hidden: new Set(),
+    });
+
+    await useAppStore.getState().rescheduleNotifications();
+
+    const passedContacts = scheduleAllNotifications.mock.calls[0][0] as { contactId: string }[];
+    expect(passedContacts).toHaveLength(2);
+  });
+});
+
 describe('Store - notification settings', () => {
   it('updates notification setting for a contact', async () => {
     await useAppStore.getState().updateNotificationSetting({

--- a/__tests__/widget-hidden-filter.test.ts
+++ b/__tests__/widget-hidden-filter.test.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+}));
+
+jest.mock('expo-contacts', () => ({
+  Fields: {
+    Name: 'name',
+    Birthday: 'birthday',
+    Image: 'image',
+    RawImage: 'rawImage',
+    ImageAvailable: 'imageAvailable',
+  },
+  getContactsAsync: jest.fn(),
+  getContactByIdAsync: jest.fn(),
+}));
+
+jest.mock('expo-file-system', () => ({
+  File: class {
+    base64() { return Promise.reject(new Error('no file')); }
+  },
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  readAsStringAsync: jest.fn().mockRejectedValue(new Error('no file')),
+  EncodingType: { Base64: 'base64' },
+}));
+
+jest.mock('../src/services/contacts', () => ({
+  checkContactsPermission: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../src/services/database', () => ({
+  getFavorites: jest.fn().mockResolvedValue([]),
+  getHidden: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../src/services/photoCache', () => ({
+  getCachedPhotoUri: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../src/widget/preferences', () => ({
+  resolveWidgetPreferences: jest.fn().mockResolvedValue({ isDark: false, maxEntries: 10 }),
+}));
+
+jest.mock('../src/widget/BirthdayWidget', () => ({
+  BirthdayWidget: jest.fn().mockReturnValue(null),
+}));
+
+import * as Contacts from 'expo-contacts';
+import { getFavorites, getHidden } from '../src/services/database';
+import { renderWidgetForName } from '../src/widget/widgetTaskHandler';
+
+const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + 1);
+
+const VISIBLE_CONTACT = {
+  id: 'visible1',
+  name: 'Alice',
+  birthday: { day: tomorrow.getDate(), month: tomorrow.getMonth(), year: 1990 },
+};
+
+const HIDDEN_CONTACT = {
+  id: 'hidden1',
+  name: 'Bob',
+  birthday: { day: tomorrow.getDate(), month: tomorrow.getMonth(), year: 1985 },
+};
+
+function getBirthdayIds(element: React.ReactElement): string[] {
+  const birthdays = (element.props as { birthdays: { contactId: string }[] }).birthdays;
+  return birthdays.map(b => b.contactId);
+}
+
+describe('widgetTaskHandler hidden contact filtering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Contacts.getContactsAsync as jest.Mock).mockResolvedValue({
+      data: [VISIBLE_CONTACT, HIDDEN_CONTACT],
+    });
+    (Contacts.getContactByIdAsync as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('calls getHidden once per widget render', async () => {
+    (getHidden as jest.Mock).mockResolvedValue(['hidden1']);
+    (getFavorites as jest.Mock).mockResolvedValue([]);
+
+    await renderWidgetForName('BirthdayUpcoming');
+
+    expect(getHidden).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes hidden contacts from the birthdays passed to BirthdayWidget', async () => {
+    (getHidden as jest.Mock).mockResolvedValue(['hidden1']);
+    (getFavorites as jest.Mock).mockResolvedValue([]);
+
+    const element = await renderWidgetForName('BirthdayUpcoming') as React.ReactElement;
+    const ids = getBirthdayIds(element);
+
+    expect(ids).toContain('visible1');
+    expect(ids).not.toContain('hidden1');
+  });
+
+  it('shows all contacts when getHidden returns empty list', async () => {
+    (getHidden as jest.Mock).mockResolvedValue([]);
+    (getFavorites as jest.Mock).mockResolvedValue([]);
+
+    const element = await renderWidgetForName('BirthdayUpcoming') as React.ReactElement;
+    const ids = getBirthdayIds(element);
+
+    expect(ids).toContain('visible1');
+    expect(ids).toContain('hidden1');
+  });
+
+  it('shows all contacts (no hidden filter) when getHidden throws', async () => {
+    (getHidden as jest.Mock).mockRejectedValue(new Error('db error'));
+    (getFavorites as jest.Mock).mockResolvedValue([]);
+
+    const element = await renderWidgetForName('BirthdayUpcoming') as React.ReactElement;
+    const ids = getBirthdayIds(element);
+
+    expect(ids).toContain('visible1');
+    expect(ids).toContain('hidden1');
+  });
+});

--- a/__tests__/widget-hidden-filter.test.ts
+++ b/__tests__/widget-hidden-filter.test.ts
@@ -34,6 +34,7 @@ jest.mock('../src/services/contacts', () => ({
 jest.mock('../src/services/database', () => ({
   getFavorites: jest.fn().mockResolvedValue([]),
   getHidden: jest.fn().mockResolvedValue([]),
+  getSettings: jest.fn().mockResolvedValue({ language: 'de', theme: 'light', widgetMaxEntries: 5 }),
 }));
 
 jest.mock('../src/services/photoCache', () => ({

--- a/__tests__/widget-hidden-filter.test.ts
+++ b/__tests__/widget-hidden-filter.test.ts
@@ -122,4 +122,15 @@ describe('widgetTaskHandler hidden contact filtering', () => {
     expect(ids).toContain('visible1');
     expect(ids).toContain('hidden1');
   });
+
+  it('still marks favorites when getHidden throws (independent failure)', async () => {
+    (getHidden as jest.Mock).mockRejectedValue(new Error('db error'));
+    (getFavorites as jest.Mock).mockResolvedValue(['visible1']);
+
+    const element = await renderWidgetForName('BirthdayUpcoming') as React.ReactElement;
+    const birthdays = (element.props as { birthdays: { contactId: string; isFavorite: boolean }[] }).birthdays;
+    const alice = birthdays.find(b => b.contactId === 'visible1');
+
+    expect(alice?.isFavorite).toBe(true);
+  });
 });

--- a/__tests__/widget-permission-guard.test.ts
+++ b/__tests__/widget-permission-guard.test.ts
@@ -31,6 +31,7 @@ jest.mock('../src/services/contacts', () => ({
 
 jest.mock('../src/services/database', () => ({
   getFavorites: jest.fn().mockResolvedValue([]),
+  getHidden: jest.fn().mockResolvedValue([]),
   getSettings: jest.fn().mockResolvedValue({ language: 'de', theme: 'light', widgetMaxEntries: 5 }),
 }));
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -261,8 +261,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   rescheduleNotifications: async () => {
     try {
-      const { contacts } = get();
-      await notificationsService.scheduleAllNotifications(contacts);
+      const { contacts, hidden } = get();
+      const visibleContacts = contacts.filter(c => !hidden.has(c.contactId));
+      await notificationsService.scheduleAllNotifications(visibleContacts);
     } catch (error) {
       console.error('Error rescheduling notifications:', error);
     }

--- a/src/widget/widgetTaskHandler.tsx
+++ b/src/widget/widgetTaskHandler.tsx
@@ -103,16 +103,13 @@ async function loadWidgetData(maxEntries: number): Promise<{ birthdays: Birthday
       ],
     });
 
-    // Load favorites and hidden contacts from database (handles init + retry internally)
+    // Load favorites and hidden contacts from database (handles init + retry internally).
+    // allSettled keeps each result independent: a getHidden() failure won't discard favorites.
     let favoriteIds: Set<string> = new Set();
     let hiddenIds: Set<string> = new Set();
-    try {
-      const [favs, hiddenList] = await Promise.all([getFavorites(), getHidden()]);
-      favoriteIds = new Set(favs);
-      hiddenIds = new Set(hiddenList);
-    } catch {
-      // Non-fatal: show all contacts without favorite marker or hidden filter
-    }
+    const [favsResult, hiddenResult] = await Promise.allSettled([getFavorites(), getHidden()]);
+    if (favsResult.status === 'fulfilled') favoriteIds = new Set(favsResult.value);
+    if (hiddenResult.status === 'fulfilled') hiddenIds = new Set(hiddenResult.value);
 
     const items: BirthdayItem[] = [];
 

--- a/src/widget/widgetTaskHandler.tsx
+++ b/src/widget/widgetTaskHandler.tsx
@@ -7,7 +7,7 @@ import * as LegacyFileSystem from 'expo-file-system/legacy';
 import { getDaysUntilBirthday, getUpcomingAge, formatBirthday } from '../utils/birthday';
 import { getCachedPhotoUri } from '../services/photoCache';
 import { checkContactsPermission } from '../services/contacts';
-import { getFavorites, getSettings } from '../services/database';
+import { getFavorites, getHidden, getSettings } from '../services/database';
 import { DEFAULT_SETTINGS } from '../types';
 import { resolveWidgetPreferences } from './preferences';
 
@@ -103,19 +103,22 @@ async function loadWidgetData(maxEntries: number): Promise<{ birthdays: Birthday
       ],
     });
 
-    // Load favorites from database service (handles init + retry internally)
+    // Load favorites and hidden contacts from database (handles init + retry internally)
     let favoriteIds: Set<string> = new Set();
+    let hiddenIds: Set<string> = new Set();
     try {
-      const favs = await getFavorites();
+      const [favs, hiddenList] = await Promise.all([getFavorites(), getHidden()]);
       favoriteIds = new Set(favs);
+      hiddenIds = new Set(hiddenList);
     } catch {
-      // Non-fatal: show all contacts without favorite marker
+      // Non-fatal: show all contacts without favorite marker or hidden filter
     }
 
     const items: BirthdayItem[] = [];
 
     for (const contact of data) {
       if (!contact.birthday || !contact.id) continue;
+      if (hiddenIds.has(contact.id)) continue;
 
       const birthday = {
         day: contact.birthday.day!,


### PR DESCRIPTION
Hidden (ausgeblendete) contacts were not filtered in two places:
- widgetTaskHandler.tsx: loadWidgetData now loads getHidden() alongside
  getFavorites() and skips contacts whose ID is in the hidden set.
  Falls back gracefully (shows all) if the DB call throws.
- store/index.ts: rescheduleNotifications now filters out hidden contacts
  before passing the list to scheduleAllNotifications.

Tests added:
- __tests__/widget-hidden-filter.test.ts (4 tests)
- __tests__/store.test.ts: 2 rescheduleNotifications tests
- __tests__/widget-permission-guard.test.ts: added getHidden to db mock

https://claude.ai/code/session_019p6E3XH4AGSQ749tXjD2Ye